### PR TITLE
Fix isless, isgreaterequal and isnotequal of int to use floats

### DIFF
--- a/opencl/kde.cl
+++ b/opencl/kde.cl
@@ -163,8 +163,8 @@ static inline void filter_along_rows(
     // Get the kdf weight
     const double k_value = k_sample((double)k_idx, k_width);
 
-    const uint is_ok_right = isless(hi_col_rght,(int)N_HIST_BINS);
-    const uint is_ok_left  = isnotequal(k_idx,0u) & isgreaterequal(hi_col_left,0);
+    const uint is_ok_right = isless((float)hi_col_rght,(float)N_HIST_BINS);
+    const uint is_ok_left  = isnotequal((float)k_idx,(float)0) & isgreaterequal((float)hi_col_left,(float)0);
     int hist_rght = hi_row*N_HIST_BINS+hi_col_rght;
     int hist_left = hi_row*N_HIST_BINS+hi_col_left;
     hist_rght = select(0u, (uint)hist_rght, is_ok_right);
@@ -293,8 +293,8 @@ static inline void filter_along_cols(
         for (hi_col=0u;hi_col<(int)n_bins_per_point;hi_col++) {
             hi_row_dn = hi_row_dn_offset+hi_row*N_HIST_BINS+hi_col;
             hi_row_up = hi_row_up_offset+(n_bins_per_point-1-hi_row)*N_HIST_BINS+hi_col;
-            is_ok_down = isless(hi_row_dn,(int)(N_HIST_BINS*N_HIST_BINS));
-            is_ok_up   = isnotequal(k_idx,0) & isgreaterequal(hi_row_up,0);
+            is_ok_down = isless((float)hi_row_dn,(float)(N_HIST_BINS*N_HIST_BINS));
+            is_ok_up   = isnotequal((float)k_idx,(float)0) & isgreaterequal((float)hi_row_up,(float)0);
             hi_row_dn = select(0u, (uint)hi_row_dn, is_ok_down);
             hi_row_up = select(0u, (uint)hi_row_up, is_ok_up);
             // Get histogram right & left counts for this hist bin
@@ -457,10 +457,10 @@ static inline void filter(
         k_value = k_sample(x,KDF_WIDTH_X);
         // Get histogram count for this hist bin on both sides of the symm filter
         // First check if the filter spills off the right or left array limits
-        is_ok_right = isless(pdf_col_rght,(int)N_PDF_POINTS);
+        is_ok_right = isless((float)pdf_col_rght,(float)N_PDF_POINTS);
         // When checking left also suppress accumulation if at filter center
         //   (don't count twice at the x=0 pdf bin)
-        is_ok_left  = isnotequal(k_idx,0) & isgreater(pdf_col_left,0);
+        is_ok_left  = isnotequal((float)k_idx,(float)0) & isgreater((float)pdf_col_left,(float)0);
         h_col_rght = (uint)(pdf_col_rght*n_bins_per_point+h_col);
         h_col_left = (uint)(pdf_col_left*n_bins_per_point-h_col-1u);
         // Map R&L col indexes into dummy value zero index if off grid


### PR DESCRIPTION
OpenCl does not have isless, isnotequal and isgreaterequal functions of ints, only of float, double and half.

Why this passes on the Mac is a puzzle for me.
