### PR TITLE
Changed path of IndianCreek tests from 'Data' to 'data'

### DIFF
--- a/tests/IndianCreek_Test1.json
+++ b/tests/IndianCreek_Test1.json
@@ -15,7 +15,7 @@
 		"title" :          "Indian Creek Test#1, Ohio, USA",
 		"dtm_file" :       "IndianCreek_res1m_fillsinks0p01_cuttest2.tif",
 		"basins_file" :    "IndianCreek_DTM0_res1m_fill_sinks1deg_watershed30k_cuttest2.tif",
-		"data_path" :      ["..", "Data"],	
+		"data_path" :      ["..", "data"],	
 		"export_path" :    [".","IndianCreek_Test1"],		
 		"no_data_values" : [-99999,0],
 		"do_clip_roi" :    true,

--- a/tests/IndianCreek_Test2.json
+++ b/tests/IndianCreek_Test2.json
@@ -3,7 +3,7 @@
 		"title" :         "Indian Creek Test#2, Ohio, USA",
 		"dtm_file" :      "IndianCreek_res1m_fillsinks0p01_cuttest2.tif",
 		"basins_file" :   "IndianCreek_DTM0_res1m_fill_sinks1deg_watershed3k_cuttest2.tif",
-		"data_path" :     [ "..", "Data" ],
+		"data_path" :     [ "..", "data" ],
 		"export_path" :   [ ".",  "IndianCreek_Test2" ],
 		"do_clip_roi" :   false,
 		"basins" :        [1131,1132],		


### PR DESCRIPTION
The data path in the Json is 'Data'; the path in the repo is 'data'.
This works on a Mac that has case-insensitive file systems; Linux does not.
