### PR TITLE
Fix np.bool and np.complex which are not in Numpy 1.23 and above

### DIFF
--- a/Packages/streamlines/analysis.py
+++ b/Packages/streamlines/analysis.py
@@ -609,7 +609,7 @@ class Analysis(Core):
         
         self.mapping.midslope_array \
             = (self.mapping.mapping_array 
-               & self.mapping.info.is_midslope).copy().astype(np.bool)
+               & self.mapping.info.is_midslope).copy().astype(bool)
         
         h_midline_pts \
             = self.geodata.roi_array[self.mapping.midslope_array[2:-2,2:-2]].ravel()
@@ -894,8 +894,8 @@ class Bivariate_distribution():
         # x,y meshgrid for sampling the bivariate pdf f(x,y)
         # For some weird reason, the numbers of points in x,y need to be complex-valued 
         self.logx_mesh,self.logy_mesh \
-            = np.mgrid[logx_min:logx_max:np.complex(n_pdf_points),
-                       logy_min:logy_max:np.complex(n_pdf_points)]
+            = np.mgrid[logx_min:logx_max:complex(n_pdf_points),
+                       logy_min:logy_max:complex(n_pdf_points)]
         self.logxy_data_indexes = np.vstack([self.logx_mesh.ravel(), 
                                              self.logy_mesh.ravel()]).T
         self.logx_min     = logx_min

--- a/Packages/streamlines/mapping.py
+++ b/Packages/streamlines/mapping.py
@@ -255,7 +255,7 @@ class Mapping(Core):
         # Create arrays for mapping and coarse subsegmentation
         self.mapping_array            = np.zeros((nxp,nyp), dtype=np.uint32)
         self.coarse_subsegment_array  = np.zeros((nxp,nyp), dtype=np.int32)
-        self.merged_coarse_mask_array = np.ones((nxp,nyp),  dtype=np.bool)
+        self.merged_coarse_mask_array = np.ones((nxp,nyp),  dtype=bool)
         # Create an info object for passing parameters to CL wrappers etc
         info = Info(self.state, self.trace, self.geodata.roi_pixel_size, mapping=self)
         # Revert to 'dtm', 'basin' (if set), and 'uv' masks only
@@ -410,9 +410,9 @@ class Mapping(Core):
         self.state.add_active_mask({'merged_coarse': self.merged_coarse_mask_array})
         # Initialize the full ROI-scale HSL grid and a buffer
         # Also a mapping array for channels etc
-        raw_mask_array      = np.zeros((nxp,nyp), dtype=np.bool)
-        dilated_mask_array  = np.zeros((nxp,nyp), dtype=np.bool)
-        merged_mask_array   = np.zeros((nxp,nyp), dtype=np.bool)
+        raw_mask_array      = np.zeros((nxp,nyp), dtype=bool)
+        dilated_mask_array  = np.zeros((nxp,nyp), dtype=bool)
+        merged_mask_array   = np.zeros((nxp,nyp), dtype=bool)
         self.hsl_array      = np.zeros((nxp,nyp), dtype=np.float32)
         self.hsl_mean_array = np.array([], dtype=np.float32)
         self.hsl_stats_df   = None
@@ -608,10 +608,10 @@ class Mapping(Core):
         # Map smoothed terrain aspect aka orientation relative to east from uv array
         self.map_aspect(info)
         # Make 1-byte boolean arrays of selected mapping flags
-        self.thinchannel_array = np.zeros((nxp,nyp), dtype=np.bool)
-        self.channelhead_array = np.zeros((nxp,nyp), dtype=np.bool)
-        self.midslope_array    = np.zeros((nxp,nyp), dtype=np.bool)
-        self.ridge_array       = np.zeros((nxp,nyp), dtype=np.bool)
+        self.thinchannel_array = np.zeros((nxp,nyp), dtype=bool)
+        self.channelhead_array = np.zeros((nxp,nyp), dtype=bool)
+        self.midslope_array    = np.zeros((nxp,nyp), dtype=bool)
+        self.ridge_array       = np.zeros((nxp,nyp), dtype=bool)
         self.thinchannel_array[(self.mapping_array & info.is_thinchannel)>0] = True
         self.channelhead_array[(self.mapping_array & info.is_channelhead)>0] = True
         self.midslope_array[   (self.mapping_array & info.is_midslope)>0]    = True
@@ -709,7 +709,7 @@ class Mapping(Core):
         nxp = info.nx_padded
         nyp = info.ny_padded
         mapping_array = data.mapping_array
-        channel_array = np.zeros((nxp,nyp), dtype=np.bool)
+        channel_array = np.zeros((nxp,nyp), dtype=bool)
         channel_array[  ((mapping_array & info.is_channel)==info.is_channel)
                       | ((mapping_array & info.is_interchannel)==info.is_interchannel)
                      ] = True
@@ -783,7 +783,7 @@ class Mapping(Core):
         mask = data.mask_array
         nxp  = info.nx_padded
         nyp  = info.ny_padded
-        midslope_array = np.zeros((nxp,nyp), dtype=np.bool)
+        midslope_array = np.zeros((nxp,nyp), dtype=bool)
 #         pdebug('self.midslope_filter_sigma', self.midslope_filter_sigma)
         midslope_array[ (~mask) & (np.fabs(
             gaussian_filter((np.arctan2(dsla,usla)-np.pi/4), self.midslope_filter_sigma))
@@ -798,8 +798,8 @@ class Mapping(Core):
         mask = data.mask_array
         nxp  = info.nx_padded
         nyp  = info.ny_padded
-        ridge_array = np.zeros((nxp,nyp), dtype=np.bool)
-        fat_ridge_array = np.zeros((nxp,nyp), dtype=np.bool)
+        ridge_array = np.zeros((nxp,nyp), dtype=bool)
+        fat_ridge_array = np.zeros((nxp,nyp), dtype=bool)
         ridge_array[ (~mask) & ((
             gaussian_filter((np.arctan2(dsla,usla)-np.pi/4), self.ridge_filter_sigma))
                              <= -(np.pi/4)*self.ridge_threshold)] = True
@@ -841,9 +841,9 @@ class Mapping(Core):
     def fmm_lengths(self, info, data):
         data.subsegment_hsl_array = np.zeros_like(data.selected_subsegments_array)
         for idx,subsegment in enumerate(data.selected_subsegments_array):
-            phi_bool = np.zeros_like(data.label_array,dtype=np.bool)
+            phi_bool = np.zeros_like(data.label_array,dtype=bool)
             phi_mod  = np.zeros_like(data.label_array,dtype=np.int32)
-            mask     = np.zeros_like(data.label_array,dtype=np.bool)
+            mask     = np.zeros_like(data.label_array,dtype=bool)
             phi_bool[np.abs(data.label_array)==np.abs(subsegment)]=True
             n_phi_pixels = phi_bool[phi_bool==True].size
             n_erosions = 0
@@ -1030,7 +1030,7 @@ class Mapping(Core):
         # Copy the slope grid because we're going to monkey with it
         slope_array     = self.preprocess.slope_array.copy()
         uv_array        = self.preprocess.uv_array
-        mask_array      = np.zeros((nxp,nyp), dtype=np.bool)
+        mask_array      = np.zeros((nxp,nyp), dtype=bool)
         slope_array[((self.mapping_array & info.is_channel)==info.is_channel)] = 0.0
         median_radius = self.aspect_median_filter_radius/self.geodata.pixel_size
         if self.do_aspect_median_filtering:

--- a/Packages/streamlines/plot.py
+++ b/Packages/streamlines/plot.py
@@ -520,12 +520,12 @@ class Plot(Core):
         
         active_mask_array = self.state.merge_active_masks()
         
-        grid_array = (self.mapping.mapping_array & is_thinchannel).copy().astype(np.bool)
+        grid_array = (self.mapping.mapping_array & is_thinchannel).copy().astype(bool)
         mask_array = active_mask_array | ~(grid_array)
         self.plot_simple_grid(grid_array, mask_array, axes, cmap='Blues', alpha=0.8)
 
-        grid_array = (self.mapping.mapping_array & is_midslope).copy().astype(np.bool)
-        fat_grid_array = np.zeros_like(grid_array, dtype=np.bool)
+        grid_array = (self.mapping.mapping_array & is_midslope).copy().astype(bool)
+        fat_grid_array = np.zeros_like(grid_array, dtype=bool)
         dilation_structure = generate_binary_structure(2, 2)
         binary_dilation(grid_array, structure=dilation_structure, 
                         iterations=self.n_midslope_iterations, 
@@ -533,8 +533,8 @@ class Plot(Core):
         mask_array = active_mask_array | ~(fat_grid_array)
         self.plot_simple_grid(fat_grid_array, mask_array, axes, cmap='Greens', alpha=0.8)
         
-        grid_array = (self.mapping.mapping_array & is_ridge).copy().astype(np.bool)
-        fat_grid_array = np.zeros_like(grid_array, dtype=np.bool)
+        grid_array = (self.mapping.mapping_array & is_ridge).copy().astype(bool)
+        fat_grid_array = np.zeros_like(grid_array, dtype=bool)
         dilation_structure = generate_binary_structure(2, 2)
         binary_dilation(grid_array, structure=dilation_structure,
                         iterations=self.n_ridge_iterations, 
@@ -735,7 +735,7 @@ class Plot(Core):
             else:
                 z_max = self.hsl_z_max
         grid_array = np.clip(self.mapping.hsl_array.copy(),z_min,z_max)
-#         mask_array = np.zeros_like(grid_array).astype(np.bool)
+#         mask_array = np.zeros_like(grid_array).astype(bool)
         mask_array = self.state.merge_active_masks()
         mask_array[grid_array<=5] = True
 #         pdebug('list_active_masks',self.state.list_active_masks())
@@ -1278,7 +1278,7 @@ class Plot(Core):
             TBD
         """
         if mask_array is None:
-            mask_array = np.zeros_like(grid_array).astype(np.bool)
+            mask_array = np.zeros_like(grid_array).astype(bool)
         pad = self.geodata.pad_width
         pslice = np.index_exp[pad:-pad,pad:-pad]
         mask_array = mask_array[pslice]
@@ -1309,7 +1309,7 @@ class Plot(Core):
             grid_alpha = 1.0
 
         grid_array = grid_array[pslice]
-#         extra_mask_array = grid_array.astype(np.bool)
+#         extra_mask_array = grid_array.astype(bool)
 #         mask_array = mask_array | (~extra_mask_array)
 #         mask_array &= False
         masked_grid_array = np.ma.masked_array(grid_array, mask=mask_array)
@@ -1346,7 +1346,7 @@ class Plot(Core):
 #         try:
 #             is_thinchannel = self.mapping.info.is_thinchannel
 #             grid_array = ( self.mapping.mapping_array[pslice] 
-#                            & is_thinchannel ).astype(np.bool)
+#                            & is_thinchannel ).astype(bool)
 #             im = axes.imshow(np.flipud(grid_array.T), 
 #                       cmap='Blues', 
 #                       extent=[*self.geodata.roi_x_bounds,*self.geodata.roi_y_bounds],

--- a/Packages/streamlines/useful.py
+++ b/Packages/streamlines/useful.py
@@ -382,7 +382,7 @@ def write_geotiff(path, file_name, array, nx,ny,npd, pslice, geodata):
     dataset.SetProjection(geodata.tiff.GetProjection())
     geotransform = geodata.tiff.GetGeoTransform()
     rotated_array = np.flipud(array[pslice].T)
-    if array.dtype==np.bool:
+    if array.dtype==bool:
         dataset.GetRasterBand(1).WriteArray(rotated_array.astype(np.uint8))
     else:
         dataset.GetRasterBand(1).WriteArray(rotated_array)


### PR DESCRIPTION
np.bool is a synonym for bool; np.complex is a synonym for complex - up to numpy 1.23
Beyond they are removed.
Hence this PR changes np.bool to bool, and np.complex to complex.
Note np.bool8 is unchanged,
